### PR TITLE
fix: set quiet goodnight download to pruned link

### DIFF
--- a/stable_diffusion.json
+++ b/stable_diffusion.json
@@ -6819,7 +6819,7 @@
                 {
                     "file_name": "qg_xl.safetensors",
                     "file_path": "",
-                    "file_url": "https://civitai.com/api/download/models/375465?type=Model&format=SafeTensor&size=full&fp=fp16"
+                    "file_url": "https://civitai.com/api/download/models/375465?type=Model&format=SafeTensor&size=pruned&fp=fp16"
                 }
             ]
         },


### PR DESCRIPTION
My guess is that the model author retroactively (and correctly) marked the model as pruned, causing the original link to be now invalid. 