### PR TITLE
Fixing Nova Anime XL's version: number -> name

### DIFF
--- a/stable_diffusion.json
+++ b/stable_diffusion.json
@@ -6700,7 +6700,7 @@
         "type": "ckpt",
         "inpainting": false,
         "description": "Anime 2d/2.5d model, emphasis on detailed fur, scales, feathers, etc.",
-        "version": "8.0",
+        "version": "Illustrious v1.0",
         "style": "anime",
         "homepage": "https://civitai.com/models/376130?modelVersionId=1065689",
         "nsfw": true,


### PR DESCRIPTION
Fixing Nova Anime XL's version: number (v8.0) -> name (Illustrious v1.0)