### PR TITLE
fix: remove flux fp16

### DIFF
--- a/stable_diffusion.json
+++ b/stable_diffusion.json
@@ -6241,52 +6241,6 @@
         ],
         "size_on_disk_bytes": 13776906831
     },
-    "Flux.1-Schnell fp16 (Compact)": {
-        "name": "Flux.1-Schnell fp16 (Compact)",
-        "baseline": "flux_1",
-        "type": "ckpt",
-        "inpainting": false,
-        "description": "FLUX.1 [dev] is a 12 billion parameter rectified flow transformer capable of generating images from text descriptions. For more information, please read our blog post. https://blackforestlabs.ai/",
-        "version": "1.0",
-        "style": "generalist",
-        "homepage": "https://civitai.com/models/637170?modelVersionId=716322",
-        "nsfw": false,
-        "download_all": false,
-        "requirements": {
-            "min_steps": 20,
-            "max_steps": 30,
-            "min_cfg_scale": 1,
-            "max_cfg_scale": 4,
-            "clip_skip": 1,
-            "samplers": [
-                "k_euler"
-            ],
-            "schedulers": [
-                "karras"
-            ]
-        },
-        "config": {
-            "files": [
-                {
-                    "path": "flux1CompactCLIPAnd_Flux1SchnellFp16.safetensors",
-                    "sha256sum": "9A7E0ABFF3ED182D9F9FF4F8B0E9AA7514A4EC828E5C406999A7B5D27F3FEB22"
-                }
-            ],
-            "download": [
-                {
-                    "file_name": "flux1CompactCLIPAnd_Flux1SchnellFp16.safetensors",
-                    "file_path": "",
-                    "file_url": "https://civitai.com/api/download/models/716322?type=Model&format=SafeTensor&size=full"
-                }
-            ]
-        },
-        "features_not_supported": [
-            "hires_fix",
-            "inpainting",
-            "controlnet"
-        ],
-        "size_on_disk_bytes": 17246524772
-    },
     "Flux.1-Schnell fp8 (Compact)": {
         "name": "Flux.1-Schnell fp8 (Compact)",
         "baseline": "flux_1",


### PR DESCRIPTION
The model is:
- Very large and consumes an undue amount of high-capability workers and their capacity
- Problematic from a stability point of view due to it size
- All around more hassle than its worth.

The above reasons have led to poor adoption by workers and a marked increase in my gray hairs. I am therefore removing it for the time being until better worker/horde-engine support can be demonstrated.